### PR TITLE
fix: copy minimal SLDS assets for PWA

### DIFF
--- a/apps/ecars-pwa/scripts/copySldsAssets.js
+++ b/apps/ecars-pwa/scripts/copySldsAssets.js
@@ -1,10 +1,14 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-fs.copySync(
-    path.join(
-        '__dirname',
-        '../node_modules/@salesforce-ux/design-system/assets'
-    ),
-    path.join('__dirname', '../src/client/resources/assets')
-);
+const SLDS_SUBFOLDERS = ['fonts', `icons${path.sep}utility-sprite`, 'styles'];
+
+SLDS_SUBFOLDERS.forEach((sub) => {
+    fs.copySync(
+        path.join(
+            '__dirname',
+            `../node_modules/@salesforce-ux/design-system/assets/${sub}`
+        ),
+        path.join('__dirname', `../src/client/resources/assets/${sub}`)
+    );
+});


### PR DESCRIPTION
### What does this PR do?

This PR changes the `copySldsAssets.js` script, by controlling more which assets are provided to the app.

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[x] Code linting and formatting was performed.

### Functionality Before

The PWA was loading the whole set of SLDS assets for precaching.

### Functionality After

Only a subset of SLDS assets are now made available to the build.
