### PR TITLE
Remove security token requirement

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -7,7 +7,6 @@ package.xml
 **appMenu
 **appSwitcher
 **objectTranslations
-**profiles
 **settings
 force-app/main/default/lwc/liveData*
 

--- a/README.md
+++ b/README.md
@@ -101,12 +101,6 @@ The below steps do everything the [Automated Deploy](#automated-deploy) does. It
     $ sfdx force:user:password:generate -u ecars
     ```
 
-1. Generate a Security Token for the scratch org user. Run the following command and then click Reset Security Token. You will receive the security token in an email. This will be used later for the `SF_TOKEN` config var in the Heroku apps.
-
-    ```console
-    $ sfdx force:org:open -u ecars -p /lightning/settings/personal/ResetApiToken/home
-    ```
-
 1. (Optional) Activate the `Pulsar_Bold` theme on the `Themes and Branding` page by running the following command:
 
     ```console
@@ -172,7 +166,7 @@ The below steps do everything the [Automated Deploy](#automated-deploy) does. It
     1. Set config vars
 
         ```console
-        $ heroku config:set VAPID_PUBLIC_KEY=[VAPID PUBLIC KEY] VAPID_PRIVATE_KEY=[VAPID PRIVATE KEY] SF_USERNAME=[SCRATCH ORG USERNAME] SF_PASSWORD=[SCRATCH ORG USER'S PASSWORD] SF_TOKEN=[SCRATCH ORG USER'S TOKEN] --app=[PWA NAME]
+        $ heroku config:set VAPID_PUBLIC_KEY=[VAPID PUBLIC KEY] VAPID_PRIVATE_KEY=[VAPID PRIVATE KEY] SF_USERNAME=[SCRATCH ORG USERNAME] SF_PASSWORD=[SCRATCH ORG USER'S PASSWORD] --app=[PWA NAME]
         ```
 
 1. Deploy and configure the **Heroku Microservices Application**
@@ -190,7 +184,7 @@ The below steps do everything the [Automated Deploy](#automated-deploy) does. It
     1. Set config vars
 
         ```console
-        $ heroku config:set VAPID_PUBLIC_KEY=[VAPID PUBLIC KEY] VAPID_PRIVATE_KEY=[VAPID PRIVATE KEY] SF_USERNAME=[SCRATCH ORG USERNAME] SF_PASSWORD=[SCRATCH ORG USER'S PASSWORD] SF_TOKEN=[SCRATCH ORG USER'S TOKEN] SF_LOGIN_URL=[SCRATCH ORG LOGIN URL] --app=[MICROSERVICES APP NAME]
+        $ heroku config:set VAPID_PUBLIC_KEY=[VAPID PUBLIC KEY] VAPID_PRIVATE_KEY=[VAPID PRIVATE KEY] SF_USERNAME=[SCRATCH ORG USERNAME] SF_PASSWORD=[SCRATCH ORG USER'S PASSWORD] SF_LOGIN_URL=[SCRATCH ORG LOGIN URL] --app=[MICROSERVICES APP NAME]
         ```
 
 1. Deploy source to the **Saleforce scratch org**

--- a/apps/ecars-pwa/src/server/api.js
+++ b/apps/ecars-pwa/src/server/api.js
@@ -22,7 +22,7 @@ For a real-live implementation you should use the JWT Bearer Flow.
 */
 const SF_USERNAME = process.env.SF_USERNAME;
 const SF_PASSWORD = process.env.SF_PASSWORD;
-const SF_TOKEN = process.env.SF_TOKEN;
+const SF_TOKEN = process.env.SF_TOKEN || '';
 
 const conn = new jsforce.Connection({
     loginUrl: 'https://test.salesforce.com'

--- a/apps/ecars-services/routes/pdf/Salesforce.ts
+++ b/apps/ecars-services/routes/pdf/Salesforce.ts
@@ -16,7 +16,7 @@ export default class Salesforce {
 
         await conn.login(
             process.env.SF_USERNAME,
-            process.env.SF_PASSWORD + process.env.SF_TOKEN
+            process.env.SF_PASSWORD + (process.env.SF_TOKEN || '')
         );
         this.conn = conn;
     }

--- a/force-app/main/default/profiles/Admin.profile-meta.xml
+++ b/force-app/main/default/profiles/Admin.profile-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Profile xmlns="http://soap.sforce.com/2006/04/metadata">
+    <loginIpRanges>
+        <description>the whole internet</description>
+        <startAddress>0.0.0.0</startAddress>
+        <endAddress>255.255.255.255</endAddress>
+    </loginIpRanges>
+</Profile>

--- a/scripts/ecarsDeploy.js
+++ b/scripts/ecarsDeploy.js
@@ -508,49 +508,12 @@ function showFinalInstructions() {
     log('');
     log(
         chalk.bgWhite.green.bold(
-            ' Almost done!! Now, please complete the following steps '
+            " Deploy done!! Here's how to start using the demo "
         )
     );
     log('');
-    log('1. Run this sfdx CLI command:');
     log(
-        chalk.dim(
-            `       sfdx force:org:open -u ${sh.env.SFDX_SCRATCH_ORG} -p /lightning/settings/personal/ResetApiToken/home`
-        )
-    );
-    log("2. Click 'Reset Security Token' on the page that the above command");
-    log('    opens to generate a Security Token.');
-    log(
-        '3. Copy the Security Token from your email, and add it as a Config Var'
-    );
-    log('    named SF_TOKEN to two of the Heroku apps that were just deployed');
-    log(
-        '    (' +
-            chalk.bold(sh.env.HEROKU_SERVICES_APP_NAME) +
-            ' and ' +
-            chalk.bold(sh.env.HEROKU_PWA_APP_NAME) +
-            '):'
-    );
-    log('    Here are the two Heroku CLI commands to run to do this:');
-    log(
-        '    (Replace abc in each command with the Security Token from your email)'
-    );
-    log(
-        chalk.dim(
-            '       heroku config:set --app ' +
-                sh.env.HEROKU_SERVICES_APP_NAME +
-                ' SF_TOKEN=abc'
-        )
-    );
-    log(
-        chalk.dim(
-            '       heroku config:set --app ' +
-                sh.env.HEROKU_PWA_APP_NAME +
-                ' SF_TOKEN=abc'
-        )
-    );
-    log(
-        '4. (Optional) Run this sfdx CLI command, and activate the `Pulsar Bold` theme:'
+        '1. (Optional) Run this sfdx CLI command, and activate the `Pulsar Bold` theme:'
     );
     log(
         chalk.dim(
@@ -558,12 +521,11 @@ function showFinalInstructions() {
         )
     );
     log(
-        '5. Now run the following two CLI commands to start playing with the demo:'
+        '2. Now run the following two CLI commands to start playing with the demo:'
     );
     log(
-        `       Start as a consumer interested in buying a Pulsar Motors car: ${chalk.dim(
-            'heroku open --app ' + sh.env.HEROKU_PWA_APP_NAME
-        )}`
+        `       Start as a consumer interested in buying a Pulsar Motors car: 
+        ${chalk.dim(`heroku open --app ${sh.env.HEROKU_PWA_APP_NAME}`)}`
     );
     log(`       Proceed as a Pulsar Motors Salesperson: 
         ${chalk.dim(


### PR DESCRIPTION
### What does this PR do?

Removes the need to use a security token in Salesforce API requests made by the Heroku apps. This PR adds a profile that allows logins from any IP address in the `0.0.0.0` to `255.255.255.255` range (i.e. the entire internet). Username and password are still required, but 1) for API requests, a security token is not required and 2) for web login, an emailed verification code is not required.

_**IMPORTANT NOTE: This profile shouldn't be used in production deploys!**_


[ ] ~~Tests for the proposed changes have been added/updated.~~ (n/a)
[x] Code linting and formatting was performed.

### Functionality Before

- `SF_TOKEN` env var required in services and pwa heroku apps
- Manual steps required to complete demo deploy
- "Verify Your Identity..." code from email required to login to scratch org through web interface

### Functionality After

- Removes need for `SF_TOKEN` env var in the services and pwa heroku apps
- No more manual steps to complete demo deploy
- If you share the Salesforce scratch org username and password to a colleague so they can check out the demo, you won't need to also share the verification code from the "Verify Your Identity..." email that will be generated when your colleague tries to log in from their browser.
