### PR TITLE
Revert "Remove security token requirement"

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -7,6 +7,7 @@ package.xml
 **appMenu
 **appSwitcher
 **objectTranslations
+**profiles
 **settings
 force-app/main/default/lwc/liveData*
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ The below steps do everything the [Automated Deploy](#automated-deploy) does. It
     $ sfdx force:user:password:generate -u ecars
     ```
 
+1. Generate a Security Token for the scratch org user. Run the following command and then click Reset Security Token. You will receive the security token in an email. This will be used later for the `SF_TOKEN` config var in the Heroku apps.
+
+    ```console
+    $ sfdx force:org:open -u ecars -p /lightning/settings/personal/ResetApiToken/home
+    ```
+
 1. (Optional) Activate the `Pulsar_Bold` theme on the `Themes and Branding` page by running the following command:
 
     ```console
@@ -166,7 +172,7 @@ The below steps do everything the [Automated Deploy](#automated-deploy) does. It
     1. Set config vars
 
         ```console
-        $ heroku config:set VAPID_PUBLIC_KEY=[VAPID PUBLIC KEY] VAPID_PRIVATE_KEY=[VAPID PRIVATE KEY] SF_USERNAME=[SCRATCH ORG USERNAME] SF_PASSWORD=[SCRATCH ORG USER'S PASSWORD] --app=[PWA NAME]
+        $ heroku config:set VAPID_PUBLIC_KEY=[VAPID PUBLIC KEY] VAPID_PRIVATE_KEY=[VAPID PRIVATE KEY] SF_USERNAME=[SCRATCH ORG USERNAME] SF_PASSWORD=[SCRATCH ORG USER'S PASSWORD] SF_TOKEN=[SCRATCH ORG USER'S TOKEN] --app=[PWA NAME]
         ```
 
 1. Deploy and configure the **Heroku Microservices Application**
@@ -184,7 +190,7 @@ The below steps do everything the [Automated Deploy](#automated-deploy) does. It
     1. Set config vars
 
         ```console
-        $ heroku config:set VAPID_PUBLIC_KEY=[VAPID PUBLIC KEY] VAPID_PRIVATE_KEY=[VAPID PRIVATE KEY] SF_USERNAME=[SCRATCH ORG USERNAME] SF_PASSWORD=[SCRATCH ORG USER'S PASSWORD] SF_LOGIN_URL=[SCRATCH ORG LOGIN URL] --app=[MICROSERVICES APP NAME]
+        $ heroku config:set VAPID_PUBLIC_KEY=[VAPID PUBLIC KEY] VAPID_PRIVATE_KEY=[VAPID PRIVATE KEY] SF_USERNAME=[SCRATCH ORG USERNAME] SF_PASSWORD=[SCRATCH ORG USER'S PASSWORD] SF_TOKEN=[SCRATCH ORG USER'S TOKEN] SF_LOGIN_URL=[SCRATCH ORG LOGIN URL] --app=[MICROSERVICES APP NAME]
         ```
 
 1. Deploy source to the **Saleforce scratch org**

--- a/apps/ecars-pwa/src/server/api.js
+++ b/apps/ecars-pwa/src/server/api.js
@@ -22,7 +22,7 @@ For a real-live implementation you should use the JWT Bearer Flow.
 */
 const SF_USERNAME = process.env.SF_USERNAME;
 const SF_PASSWORD = process.env.SF_PASSWORD;
-const SF_TOKEN = process.env.SF_TOKEN || '';
+const SF_TOKEN = process.env.SF_TOKEN;
 
 const conn = new jsforce.Connection({
     loginUrl: 'https://test.salesforce.com'

--- a/apps/ecars-services/routes/pdf/Salesforce.ts
+++ b/apps/ecars-services/routes/pdf/Salesforce.ts
@@ -16,7 +16,7 @@ export default class Salesforce {
 
         await conn.login(
             process.env.SF_USERNAME,
-            process.env.SF_PASSWORD + (process.env.SF_TOKEN || '')
+            process.env.SF_PASSWORD + process.env.SF_TOKEN
         );
         this.conn = conn;
     }

--- a/force-app/main/default/profiles/Admin.profile-meta.xml
+++ b/force-app/main/default/profiles/Admin.profile-meta.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<Profile xmlns="http://soap.sforce.com/2006/04/metadata">
-    <loginIpRanges>
-        <description>the whole internet</description>
-        <startAddress>0.0.0.0</startAddress>
-        <endAddress>255.255.255.255</endAddress>
-    </loginIpRanges>
-</Profile>

--- a/scripts/ecarsDeploy.js
+++ b/scripts/ecarsDeploy.js
@@ -508,12 +508,49 @@ function showFinalInstructions() {
     log('');
     log(
         chalk.bgWhite.green.bold(
-            " Deploy done!! Here's how to start using the demo "
+            ' Almost done!! Now, please complete the following steps '
         )
     );
     log('');
+    log('1. Run this sfdx CLI command:');
     log(
-        '1. (Optional) Run this sfdx CLI command, and activate the `Pulsar Bold` theme:'
+        chalk.dim(
+            `       sfdx force:org:open -u ${sh.env.SFDX_SCRATCH_ORG} -p /lightning/settings/personal/ResetApiToken/home`
+        )
+    );
+    log("2. Click 'Reset Security Token' on the page that the above command");
+    log('    opens to generate a Security Token.');
+    log(
+        '3. Copy the Security Token from your email, and add it as a Config Var'
+    );
+    log('    named SF_TOKEN to two of the Heroku apps that were just deployed');
+    log(
+        '    (' +
+            chalk.bold(sh.env.HEROKU_SERVICES_APP_NAME) +
+            ' and ' +
+            chalk.bold(sh.env.HEROKU_PWA_APP_NAME) +
+            '):'
+    );
+    log('    Here are the two Heroku CLI commands to run to do this:');
+    log(
+        '    (Replace abc in each command with the Security Token from your email)'
+    );
+    log(
+        chalk.dim(
+            '       heroku config:set --app ' +
+                sh.env.HEROKU_SERVICES_APP_NAME +
+                ' SF_TOKEN=abc'
+        )
+    );
+    log(
+        chalk.dim(
+            '       heroku config:set --app ' +
+                sh.env.HEROKU_PWA_APP_NAME +
+                ' SF_TOKEN=abc'
+        )
+    );
+    log(
+        '4. (Optional) Run this sfdx CLI command, and activate the `Pulsar Bold` theme:'
     );
     log(
         chalk.dim(
@@ -521,11 +558,12 @@ function showFinalInstructions() {
         )
     );
     log(
-        '2. Now run the following two CLI commands to start playing with the demo:'
+        '5. Now run the following two CLI commands to start playing with the demo:'
     );
     log(
-        `       Start as a consumer interested in buying a Pulsar Motors car: 
-        ${chalk.dim(`heroku open --app ${sh.env.HEROKU_PWA_APP_NAME}`)}`
+        `       Start as a consumer interested in buying a Pulsar Motors car: ${chalk.dim(
+            'heroku open --app ' + sh.env.HEROKU_PWA_APP_NAME
+        )}`
     );
     log(`       Proceed as a Pulsar Motors Salesperson: 
         ${chalk.dim(


### PR DESCRIPTION
Reverts trailheadapps/ecars#43

After internal discussion, we don't want to encourage allowing `0.0.0.0` to `255.255.255.255` IP addresses to not require a security token. It's not a "best practice" that other Salesforce devs should use.