### PR TITLE
Added CodeTour as a recommended VS Code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+     "vsls-contrib.codetour"
+  ]
+}


### PR DESCRIPTION
Added CodeTour as a recommended VS Code extension. This brings up a prompt that suggest installing the extension when the user imports the project.
If users don't have the extension, our tours are pretty useless :)