### PR TITLE
fix: make metadata language independent. Fix issue #152

### DIFF
--- a/force-app/main/default/objects/Car_Options__c/Car_Options__c.object-meta.xml
+++ b/force-app/main/default/objects/Car_Options__c/Car_Options__c.object-meta.xml
@@ -162,6 +162,5 @@
     <pluralLabel>Car Options</pluralLabel>
     <searchLayouts />
     <sharingModel>ReadWrite</sharingModel>
-    <startsWith>Vowel</startsWith>
     <visibility>Public</visibility>
 </CustomObject>


### PR DESCRIPTION
### What does this PR do?

Removes `startsWith` attribute from metadata.

This attribute is not needed! It applies only to the English language and not others and we should not have it in the repo.

### What issues does this PR fix or reference?

#152 

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
