### PR TITLE
Add previous button in last step of PWA car configurator

### DIFF
--- a/apps/ecars-pwa/src/client/modules/ux/carConfigurator/carConfigurator.html
+++ b/apps/ecars-pwa/src/client/modules/ux/carConfigurator/carConfigurator.html
@@ -152,6 +152,7 @@
                         selected-range={selectedRange.label}
                         selected-exterior-color={selectedExteriorColor.label}
                         selected-interior-color={selectedInteriorColor.label}
+                        onprevious={handlePrevious}
                     ></ux-product>
                 </div>
             </template>

--- a/apps/ecars-pwa/src/client/modules/ux/carConfigurator/carConfigurator.html
+++ b/apps/ecars-pwa/src/client/modules/ux/carConfigurator/carConfigurator.html
@@ -147,7 +147,7 @@
                     </div>
                 </div>
 
-                <div class="buttons slds-m-top_x-large">
+                <div class="slds-m-top_x-large">
                     <ux-product
                         selected-range={selectedRange.label}
                         selected-exterior-color={selectedExteriorColor.label}

--- a/apps/ecars-pwa/src/client/modules/ux/product/product.css
+++ b/apps/ecars-pwa/src/client/modules/ux/product/product.css
@@ -1,7 +1,9 @@
-.content {
-    padding: 0 40px;
+:host {
+    width: 100%;
 }
 
 .buttons {
     margin-top: 8px;
+    display: flex;
+    justify-content: space-between;
 }

--- a/apps/ecars-pwa/src/client/modules/ux/product/product.css
+++ b/apps/ecars-pwa/src/client/modules/ux/product/product.css
@@ -1,9 +1,4 @@
-:host {
-    width: 100%;
-}
-
 .buttons {
-    margin-top: 8px;
     display: flex;
     justify-content: space-between;
 }

--- a/apps/ecars-pwa/src/client/modules/ux/product/product.html
+++ b/apps/ecars-pwa/src/client/modules/ux/product/product.html
@@ -17,7 +17,7 @@
         type="email"
         onchange={handleEmailChange}
     ></lightning-input>
-    <div class="buttons">
+    <div class="buttons slds-m-top_large">
         <lightning-button
             icon-name="utility:chevronleft"
             label="Previous"
@@ -28,7 +28,6 @@
             label="Contact Me"
             type="brand"
             onclick={handleSubscribe}
-            style="padding-right: 4px"
         ></lightning-button>
         <lightning-button
             if:true={hasSubscription}

--- a/apps/ecars-pwa/src/client/modules/ux/product/product.html
+++ b/apps/ecars-pwa/src/client/modules/ux/product/product.html
@@ -1,42 +1,40 @@
 <template>
-    <footer>
-        <lightning-input
-            label="First Name"
-            onchange={handleFirstNameChange}
-        ></lightning-input>
-        <lightning-input
-            label="Last Name"
-            onchange={handleLastNameChange}
-        ></lightning-input>
-        <lightning-input
-            label="Mobile Phone"
-            type="tel"
-            onchange={handleCellPhoneChange}
-        ></lightning-input>
-        <lightning-input
-            label="Email"
-            type="email"
-            onchange={handleEmailChange}
-        ></lightning-input>
-        <div class="buttons">
-            <lightning-button
-                icon-name="utility:chevronleft"
-                label="Previous"
-                onclick={handlePrevious}
-            ></lightning-button>
-            <lightning-button
-                if:false={hasSubscription}
-                label="Contact Me"
-                type="brand"
-                onclick={handleSubscribe}
-                style="padding-right: 4px"
-            ></lightning-button>
-            <lightning-button
-                if:true={hasSubscription}
-                label="Unsubscribe"
-                type="brand"
-                onclick={handleUnsubscribe}
-            ></lightning-button>
-        </div>
-    </footer>
+    <lightning-input
+        label="First Name"
+        onchange={handleFirstNameChange}
+    ></lightning-input>
+    <lightning-input
+        label="Last Name"
+        onchange={handleLastNameChange}
+    ></lightning-input>
+    <lightning-input
+        label="Mobile Phone"
+        type="tel"
+        onchange={handleCellPhoneChange}
+    ></lightning-input>
+    <lightning-input
+        label="Email"
+        type="email"
+        onchange={handleEmailChange}
+    ></lightning-input>
+    <div class="buttons">
+        <lightning-button
+            icon-name="utility:chevronleft"
+            label="Previous"
+            onclick={handlePrevious}
+        ></lightning-button>
+        <lightning-button
+            if:false={hasSubscription}
+            label="Contact Me"
+            type="brand"
+            onclick={handleSubscribe}
+            style="padding-right: 4px"
+        ></lightning-button>
+        <lightning-button
+            if:true={hasSubscription}
+            label="Unsubscribe"
+            type="brand"
+            onclick={handleUnsubscribe}
+        ></lightning-button>
+    </div>
 </template>

--- a/apps/ecars-pwa/src/client/modules/ux/product/product.html
+++ b/apps/ecars-pwa/src/client/modules/ux/product/product.html
@@ -20,14 +20,21 @@
         ></lightning-input>
         <div class="buttons">
             <lightning-button
+                icon-name="utility:chevronleft"
+                label="Previous"
+                onclick={handlePrevious}
+            ></lightning-button>
+            <lightning-button
                 if:false={hasSubscription}
                 label="Contact Me"
+                type="brand"
                 onclick={handleSubscribe}
                 style="padding-right: 4px"
             ></lightning-button>
             <lightning-button
                 if:true={hasSubscription}
                 label="Unsubscribe"
+                type="brand"
                 onclick={handleUnsubscribe}
             ></lightning-button>
         </div>

--- a/apps/ecars-pwa/src/client/modules/ux/product/product.js
+++ b/apps/ecars-pwa/src/client/modules/ux/product/product.js
@@ -115,4 +115,8 @@ export default class Product extends LightningElement {
                 this.hasSubscription = isSubscribed();
             });
     }
+
+    handlePrevious() {
+        this.dispatchEvent(new CustomEvent('previous'));
+    }
 }


### PR DESCRIPTION
### What does this PR do?

Adds a previous button in the last step of the PWA car configurator.
Also fixes the contact form style.

### Before
![before](https://user-images.githubusercontent.com/5071767/110000648-d5d09780-7d13-11eb-80a5-554673da9908.png)

### After
![after](https://user-images.githubusercontent.com/5071767/110000666-d832f180-7d13-11eb-96c2-53ebc0c5f060.png)
