### PR TITLE
add SF_LOGIN_URL to ecars-pwa

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The below steps do everything the [Automated Deploy](#automated-deploy) does. It
     1. Set config vars
 
         ```console
-        $ heroku config:set VAPID_PUBLIC_KEY=[VAPID PUBLIC KEY] VAPID_PRIVATE_KEY=[VAPID PRIVATE KEY] SF_USERNAME=[SCRATCH ORG USERNAME] SF_PASSWORD=[SCRATCH ORG USER'S PASSWORD] SF_TOKEN=[SCRATCH ORG USER'S TOKEN] --app=[PWA NAME]
+        $ heroku config:set VAPID_PUBLIC_KEY=[VAPID PUBLIC KEY] VAPID_PRIVATE_KEY=[VAPID PRIVATE KEY] SF_USERNAME=[SCRATCH ORG USERNAME] SF_PASSWORD=[SCRATCH ORG USER'S PASSWORD] SF_LOGIN_URL=[SCRATCH ORG LOGIN URL] SF_TOKEN=[SCRATCH ORG USER'S TOKEN] --app=[PWA NAME]
         ```
 
 1. Deploy and configure the **Heroku Microservices Application**

--- a/apps/ecars-pwa/src/server/api.js
+++ b/apps/ecars-pwa/src/server/api.js
@@ -23,9 +23,10 @@ For a real-live implementation you should use the JWT Bearer Flow.
 const SF_USERNAME = process.env.SF_USERNAME;
 const SF_PASSWORD = process.env.SF_PASSWORD;
 const SF_TOKEN = process.env.SF_TOKEN;
+const SF_LOGIN_URL = process.env.SF_LOGIN_URL
 
 const conn = new jsforce.Connection({
-    loginUrl: 'https://test.salesforce.com'
+    loginUrl: SF_LOGIN_URL
 });
 
 // eslint-disable-next-line no-unused-vars

--- a/apps/ecars-pwa/src/server/api.js
+++ b/apps/ecars-pwa/src/server/api.js
@@ -23,7 +23,7 @@ For a real-live implementation you should use the JWT Bearer Flow.
 const SF_USERNAME = process.env.SF_USERNAME;
 const SF_PASSWORD = process.env.SF_PASSWORD;
 const SF_TOKEN = process.env.SF_TOKEN;
-const SF_LOGIN_URL = process.env.SF_LOGIN_URL
+const SF_LOGIN_URL = process.env.SF_LOGIN_URL;
 
 const conn = new jsforce.Connection({
     loginUrl: SF_LOGIN_URL

--- a/scripts/ecarsDeploy.js
+++ b/scripts/ecarsDeploy.js
@@ -418,7 +418,7 @@ function pwa_setup(..._$args) {
 
     log('*** Setting remote configuration parameters');
     sh.exec(
-        `heroku config:set APP_BASE=apps/ecars-pwa VAPID_PUBLIC_KEY='${sh.env.VAPID_PUBLIC_KEY}' VAPID_PRIVATE_KEY='${sh.env.VAPID_PRIVATE_KEY}' VAPID_EMAIL='${sh.env.VAPID_EMAIL}' SF_USERNAME='${sh.env.SF_USERNAME}' SF_PASSWORD='${sh.env.SF_PASSWORD}' -a ${sh.env.HEROKU_PWA_APP_NAME}`,
+        `heroku config:set APP_BASE=apps/ecars-pwa VAPID_PUBLIC_KEY='${sh.env.VAPID_PUBLIC_KEY}' VAPID_PRIVATE_KEY='${sh.env.VAPID_PRIVATE_KEY}' VAPID_EMAIL='${sh.env.VAPID_EMAIL}' SF_USERNAME='${sh.env.SF_USERNAME}' SF_PASSWORD='${sh.env.SF_PASSWORD}' SF_LOGIN_URL='${sh.env.SF_LOGIN_URL}' -a ${sh.env.HEROKU_PWA_APP_NAME}`,
         { silent: true }
     );
 
@@ -428,6 +428,7 @@ function pwa_setup(..._$args) {
     sh.echo('VAPID_EMAIL=' + sh.env.VAPID_EMAIL).toEnd('.env');
     sh.echo('SF_USERNAME=' + sh.env.SF_USERNAME).toEnd('.env');
     sh.echo('SF_PASSWORD=' + sh.env.SF_PASSWORD).toEnd('.env');
+    sh.echo('SF_LOGIN_URL=' + sh.env.SF_LOGIN_URL).toEnd('.env');
     sh.echo('DATABASE_URL=' + sh.env.DATABASE_PWA_URL).toEnd('.env');
 
     log('*** Pushing app to Heroku');
@@ -565,11 +566,11 @@ function showFinalInstructions() {
             'heroku open --app ' + sh.env.HEROKU_PWA_APP_NAME
         )}`
     );
-    log(`       Proceed as a Pulsar Motors Salesperson: 
+    log(`       Proceed as a Pulsar Motors Salesperson:
         ${chalk.dim(
             `sfdx force:org:open -u ${sh.env.SFDX_SCRATCH_ORG} -p /lightning/n/Car_Configurator`
         )}`);
-    log(`       Finish the demo as a Pulsar Motors Service Manager: 
+    log(`       Finish the demo as a Pulsar Motors Service Manager:
         ${chalk.dim(
             `sfdx force:org:open -u ${sh.env.SFDX_SCRATCH_ORG} -p /lightning/o/Case/list`
         )}`);


### PR DESCRIPTION
### What does this PR do?

Adds support to `SF_LOGIN_URL` env variable for `ecars-pwa`

### What issues does this PR fix or reference?

https://github.com/trailheadapps/ecars/issues/180

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[x] Code linting and formatting was performed.

### Functionality Before

No `SF_LOGIN_URL` support, just `https://test.salesforce.com`

### Functionality After

`SF_LOGIN_URL` support, defaulting to `https://test.salesforce.com` on the deploy script